### PR TITLE
Update EEPROM.h

### DIFF
--- a/EEPROM.h
+++ b/EEPROM.h
@@ -141,11 +141,11 @@ struct EEPROMClass{
     }
 
     template< typename T > const T &put( int idx, const T &t ){
-        EEPtr e = idx;
         const uint8_t *ptr = (const uint8_t*) &t;
 #ifdef __arm__
         eeprom_write_block(ptr, (void *)idx, sizeof(T));
 #else
+        EEPtr e = idx;
         for( int count = sizeof(T) ; count ; --count, ++e )  (*e).update( *ptr++ );
 #endif
         return t;


### PR DESCRIPTION
Fixed compilier warning for an unused variable in put() method when target is Teensy3.x/LC (**arm**)
