### PR TITLE
Fix [-Wignored-qualifiers]

### DIFF
--- a/EEPROM.h
+++ b/EEPROM.h
@@ -46,7 +46,7 @@ struct EERef{
 
     //Access/read members.
     uint8_t operator*() const            { return eeprom_read_byte( (uint8_t*) index ); }
-    operator const uint8_t() const       { return **this; }
+    operator uint8_t() const       { return **this; }
 
     //Assignment/write members.
     EERef &operator=( const EERef &ref ) { return *this = *ref; }
@@ -95,7 +95,7 @@ struct EEPtr{
     EEPtr( const int index )
         : index( index )                {}
 
-    operator const int() const          { return index; }
+    operator int() const          { return index; }
     EEPtr &operator=( int in )          { return index = in, *this; }
 
     //Iterator functionality.


### PR DESCRIPTION
C:\Arduino\hardware\teensy\avr\libraries\EEPROM/EEPROM.h:49:30: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
   49 |     operator const uint8_t() const       { return **this; }
      |                              ^~~~~
C:\Arduino\hardware\teensy\avr\libraries\EEPROM/EEPROM.h:98:26: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
   98 |     operator const int() const          { return index; }
      |                          ^~~~~