### PR TITLE
Update EEPROM.h

### DIFF
--- a/EEPROM.h
+++ b/EEPROM.h
@@ -30,6 +30,7 @@
 #include <type_traits>
 #endif
 
+#include <WString.h>    // need to include this so String is defined
 
 /***
     EERef class.


### PR DESCRIPTION
Add an explicit include of <WString.h> to ensure that a definition of String is available in cases where <Arduino.h> has not been previously included. WString.h includes a header guard so this change should not break any existing code.